### PR TITLE
Switched export default to module.exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,4 +43,4 @@ const MermaidPlugin = (md) => {
   }
 }
 
-export default MermaidPlugin
+module.exports = MermaidPlugin


### PR DESCRIPTION
I just changed the way you exported your module from `export default` to `module.exports`. 

I'm using this plugin as part of an open source project called Bük that you can find at https://github.com/hang-up/buuk!